### PR TITLE
Add 3.12 support

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.11'
+        python-version: '3.12-dev'
     - name: Install Python dependencies
       run: |
         python3 -m pip install -r requirements-dev.txt
@@ -34,13 +34,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ["3.8", "3.9", "3.10", "3.11"]
+        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.python_version }}
+        python-version: ${{ matrix.python_version }}-dev
     - name: Install Python dependencies
       run: |
         python${{matrix.python_version}} -m pip install -r requirements-dev.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Framework :: Pytest",
 ]
 

--- a/src/pytest_pystack/plugin.py
+++ b/src/pytest_pystack/plugin.py
@@ -93,3 +93,8 @@ def pytest_configure(config) -> None:
         print_stderr=True,
     )
     config._pystack_queue = _monitor_process.start(pystack_config)
+
+
+@pytest.hookimpl
+def pytest_sessionfinish(session, exitstatus):
+    _monitor_process.stop()

--- a/tests/test_pytest_pystack.py
+++ b/tests/test_pytest_pystack.py
@@ -179,9 +179,9 @@ def test_silent_in_debugged_tests_failing_before_timeout(testdir, monkeypatch):
 @pytest.mark.parametrize(
     ["pytestarg", "pytestconfig"],
     [
-        ("--pystack-threshold=1", ""),  # configured in CLI
-        ("", "pystack_threshold=1"),  # configured in config file
-        ("--pystack-threshold=1", "pystack_threshold=10"),  # CLI takes preference
+        ("--pystack-threshold=2", ""),  # configured in CLI
+        ("", "pystack_threshold=2"),  # configured in config file
+        ("--pystack-threshold=2", "pystack_threshold=10"),  # CLI takes preference
     ],
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
**Describe your changes**
Now that `pystack` publishes 3.12 wheels, we should be able to support 3.12. There is still a small change required to make it work (the `atexit` handler cannot be used), but it should be fairly easy to avoid that problem by using the `pytest_sessionfinish` hook instead.

**Testing performed**
Ran the tests locally with 3.12.

**Additional context**
3.12 has recently introduced a breaking change in the creation of threads, which is no longer possible to do when the interpreter is shutting down. This is why we need to change our clean-up logic.
