### PR TITLE
Prepare for release of `1.0.1`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,86 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+  release:
+    types:
+      - published
+  schedule:
+    # At 12:00 UTC on every day-of-month
+    - cron: "0 12 */1 * *"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build_dists:
+    name: Source and wheel distributions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build distributions
+        run: pipx run build[virtualenv] --sdist --wheel
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/*
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: test-deps
+          path: |
+            tests/
+            Makefile
+            requirements-dev.txt
+
+  test:
+    needs: [build_dists]
+    name: 'Test'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+    steps:
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python_version }}-dev
+    - uses: actions/download-artifact@v4
+      with:
+        name: dist
+        path: dist
+    - uses: actions/download-artifact@v4
+      with:
+        name: test-deps
+        path: .
+    - name: Install wheel
+      run: |
+        python -m pip install dist/*.whl
+    - name: Install Python dependencies
+      run: |
+        python -m pip install -r requirements-dev.txt
+    - name: Disable ptrace security restrictions
+      run: |
+        echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
+    - name: Test
+      run: |
+        make check
+
+  upload_pypi:
+    needs: [test]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@v1.8.11
+        with:
+          password: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -28,28 +28,3 @@ jobs:
     - name: Lint sources
       run: |
         make PYTHON=python${{matrix.python_version}} lint
-  test:
-    name: 'Test'
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python_version }}-dev
-    - name: Install Python dependencies
-      run: |
-        python${{matrix.python_version}} -m pip install -r requirements-dev.txt
-    - name: Install Package
-      run: |
-        python${{matrix.python_version}} -m pip install -e .
-    - name: Disable ptrace security restrictions
-      run: |
-        echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
-    - name: Test
-      run: |
-        make PYTHON=python${{matrix.python_version}} check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = 'setuptools.build_meta'
 
 [project]
 name = "pytest-pystack"
-version = "1.0.0"
+version = "1.0.1"
 description = "Plugin to run pystack after a timeout for a test suite."
 requires-python = ">=3.8"
 dependencies = [


### PR DESCRIPTION
This would be the first version to support 3.12

@mariocj89 it looks like we have no PyPI automation, do you want to publish this version manually? Or should we take the opportunity to add PyPI publishing to the Github Actions?