### PR TITLE
Disable pytest-pystack for test depending on pytester fixture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,6 @@ format:
 
 .PHONY: lint
 lint:
-	$(PYTHON) -m ruff $(python_files)
+	$(PYTHON) -m ruff check $(python_files)
 	$(PYTHON) -m isort --check $(python_files)
 	$(PYTHON) -m black --check $(python_files)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 A pytest plug-in for easy integration of PyStack in your test suite.
 
-It can be used to automatically dump the stack trace of a hanging test in your suite.
+It can be used to automatically dump the stack trace of a hanging test in your suite (with exception to test using `pytester` fixture).
 
 See [PyStack](https://github.com/bloomberg/pystack) for further information about the tool.
 

--- a/src/pytest_pystack/_monitor_process.py
+++ b/src/pytest_pystack/_monitor_process.py
@@ -53,7 +53,12 @@ def _run_monitor(config: PystackConfig, pid, queue):
         handled_test_cases.add(testcase)
 
         try:
-            if queue.get(timeout=config.threshold) != testcase:
+            new_testcase = queue.get(timeout=config.threshold)
+            if new_testcase != testcase:
+                print(
+                    f"new test {new_testcase} should not start before previous {testcase} test finished",
+                    file=sys.__stderr__,
+                )
                 raise Exception(
                     "new test should not start before previous test finished"
                 )

--- a/src/pytest_pystack/plugin.py
+++ b/src/pytest_pystack/plugin.py
@@ -62,7 +62,11 @@ def pytest_addoption(parser) -> None:
 
 @pytest.hookimpl
 def pytest_runtest_makereport(item, call):
-    if call.when in {"setup", "teardown"} and item.config._pystack_queue:
+    if (
+        call.when in {"setup", "teardown"}
+        and item.config._pystack_queue
+        and "pytester" not in item.fixturenames
+    ):
         item.config._pystack_queue.put(item.name)
 
 


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #10*

**Describe your changes**

Disable `pytest-pystack` on test that uses `pytester` fixture (that starts test in test). 

**Testing performed**

Run tests that crash on main with this change and it works now. 

**Additional context**

This is only a workaround, maybe a better solution will be to implement some stack mechanism, that will be enabled if `pytester` fixture is used. 
