### PR TITLE
Add Python 3.13 and 3.14 support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,12 +44,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.python_version }}-dev
+        python-version: ${{ matrix.python_version }}
     - uses: actions/download-artifact@v4
       with:
         name: dist

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -11,14 +11,14 @@ on:
 
 jobs:
   lint:
-    name: 'Lint'
+    name: "Lint"
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.12-dev'
+        python-version: "3.14"
     - name: Install Python dependencies
       run: |
         python3 -m pip install -r requirements-dev.txt
@@ -27,4 +27,4 @@ jobs:
         python3 -m pip install -e .
     - name: Lint sources
       run: |
-        make PYTHON=python${{matrix.python_version}} lint
+        make PYTHON=python3 lint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Framework :: Pytest",
 ]
 


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #15*

**Describe your changes**
Added Python 3.13 and 3.14 support to the project configuration and CI.

Updated the package metadata in `pyproject.toml` to include Python 3.13 and 3.14 classifiers. Extended the GitHub Actions test matrix in `.github/workflows/build.yaml` to run the test suite on Python 3.13 and 3.14 in addition to the existing supported versions. Also cleaned up `.github/workflows/validate.yaml` so the lint workflow runs correctly on Python 3.14 without referencing a nonexistent matrix variable.

**Testing performed**
Verified the updated contents of:
- `pyproject.toml`
- `.github/workflows/build.yaml`
- `.github/workflows/validate.yaml`

Validated that the workflow and metadata changes were applied as intended by checking the git diff locally.

I was not able to fully run the test suite locally in this Windows environment because local pytest execution is affected by unrelated global plugin loading and temp-directory permission issues. The main verification for this change is expected to come from GitHub Actions, where the updated matrix will confirm Python 3.13 and 3.14 compatibility.

**Additional context**
This library is pure Python and the implementation does not contain version-specific logic, so this change primarily adds official support and CI coverage for Python 3.13 and 3.14.
