### PR TITLE
ci: Switch to Trusted Publishing

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -75,6 +75,8 @@ jobs:
     needs: [test]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
+    permissions:
+      id-token: write # Required to retrieve a Trusted Publishing token
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -82,5 +84,3 @@ jobs:
           path: dist
 
       - uses: pypa/gh-action-pypi-publish@v1.13.0
-        with:
-          password: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
Stop using long-lived secrets for PyPI publishing.