### PR TITLE
Appease ruff v0.16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,3 +61,11 @@ use_parentheses = true
 line_length = 88
 known_first_party=["pytest_pystack"]
 known_third_party=["pytest"]
+
+[tool.ruff.lint]
+ignore = [
+  "FA100",  # Add `from __future__ import annotations` to every file
+]
+
+[tool.ruff.lint.isort]
+force-single-line = true

--- a/src/pytest_pystack/_debug_detect.py
+++ b/src/pytest_pystack/_debug_detect.py
@@ -29,7 +29,6 @@ def is_debugging(tracefunc):
     This is done by checking if the module that is the origin
     of the trace function is in KNOWN_DEBUGGING_MODULES.
     """
-    global KNOWN_DEBUGGING_MODULES
     if tracefunc and inspect.getmodule(tracefunc):
         parts = inspect.getmodule(tracefunc).__name__.split(".")
         for name in KNOWN_DEBUGGING_MODULES:

--- a/src/pytest_pystack/_monitor.py
+++ b/src/pytest_pystack/_monitor.py
@@ -30,7 +30,7 @@ def monitor(config: PystackConfig, pid, queue, debug_detected):
                     f"new test {new_testcase} should not start before previous {testcase} test finished",
                     file=sys.__stderr__,
                 )
-                raise Exception(
+                raise RuntimeError(
                     "new test should not start before previous test finished"
                 )
         except Empty:
@@ -41,6 +41,7 @@ def monitor(config: PystackConfig, pid, queue, debug_detected):
                 [*pystack_cmd, str(pid)],
                 stdout=subprocess.PIPE,
                 text=True,
+                check=False,
             )
             output += proc.stdout
             output += "**** PYSTACK  ***\n"


### PR DESCRIPTION
- It wants us to add `from __future__ import annotations` to every module. Ignore that rule.
- It wants us to import multiple names on the same line. Disable that.
- Remove an unnecessary use of `global`.
- Raise a subclass of `Exception` instead of `Exception` itself.
- Explicitly document that we're not checking the return code from our `subprocess.run` call.
